### PR TITLE
Fix for #346

### DIFF
--- a/Client/Core/Helper/SystemHelper.cs
+++ b/Client/Core/Helper/SystemHelper.cs
@@ -8,10 +8,20 @@ namespace xClient.Core.Helper
     {
         public static string GetUptime()
         {
-            long ticks = Stopwatch.GetTimestamp();
-            double uptime = ((double)ticks) / Stopwatch.Frequency;
-            var uptimeSpan = TimeSpan.FromSeconds(uptime);
-            return string.Format("{0}d : {1}h : {2}m : {3}s", uptimeSpan.Days, uptimeSpan.Hours, uptimeSpan.Minutes, uptimeSpan.Seconds);
+            SelectQuery query = new SelectQuery("SELECT LastBootUpTime FROM Win32_OperatingSystem WHERE Primary='true'");
+            using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(query))
+            {
+                foreach (ManagementObject mo in searcher.Get())
+                {
+                    DateTime now = DateTime.UtcNow;
+                    DateTime dtBootTime = ManagementDateTimeConverter.ToDateTime(mo.Properties["LastBootUpTime"].Value.ToString());
+                    TimeSpan uptimeSpan = TimeSpan.FromTicks((now - dtBootTime).Ticks);
+
+                    return string.Format("{0}d : {1}h : {2}m : {3}s", uptimeSpan.Days, uptimeSpan.Hours, uptimeSpan.Minutes, uptimeSpan.Seconds);
+                }
+            }
+
+            return string.Format("{0}d : {1}h : {2}m : {3}s", 0, 0, 0, 0);
         }
 
         public static string GetPcName()


### PR DESCRIPTION
This should fix issue #346 regarding incorrect uptime being returned.
Directly querying the uptime and subtracting it from the current time
(in UTC) allows us to convert it into a TimeSpan from the ticks and
obtain a significantly more accurate uptime.