### PR TITLE
Null pointer when empty client list

### DIFF
--- a/Server/Core/Networking/Server.cs
+++ b/Server/Core/Networking/Server.cs
@@ -400,7 +400,7 @@ namespace xServer.Core.Networking
 
             lock (_clientsLock)
             {
-                while (_clients.Count != 0)
+                while (_clients != null && _clients.Count != 0)
                 {
                     try
                     {


### PR DESCRIPTION
A "Null Pointer" exception happens when there's an empty client list