### PR TITLE
RemoteShell caret positioning fix

### DIFF
--- a/Server/Core/Helper/NativeMethodsHelper.cs
+++ b/Server/Core/Helper/NativeMethodsHelper.cs
@@ -8,6 +8,9 @@ namespace xServer.Core.Helper
         private const int LVM_FIRST = 0x1000;
         private const int LVM_SETITEMSTATE = LVM_FIRST + 43;
 
+        private const int WM_VSCROLL = 277;
+        private const int SB_PAGEBOTTOM = 7;
+
         public static int MakeLong(int wLow, int wHigh)
         {
             int low = (int)IntLoWord(wLow);
@@ -30,6 +33,11 @@ namespace xServer.Core.Helper
                 state = value
             };
             NativeMethods.SendMessageLVItem(handle, LVM_SETITEMSTATE, itemIndex, ref lvItem);
+        }
+
+        public static void ScrollToBottom(IntPtr handle)
+        {
+            NativeMethods.SendMessage(handle, WM_VSCROLL, SB_PAGEBOTTOM, 0);
         }
     }
 }

--- a/Server/Forms/FrmRemoteShell.cs
+++ b/Server/Forms/FrmRemoteShell.cs
@@ -101,6 +101,7 @@ namespace xServer.Forms
             {
                 txtConsoleOutput.Invoke((MethodInvoker)delegate
                 {
+                    txtConsoleOutput.SelectionColor = Color.White;
                     txtConsoleOutput.AppendText(message);
                 });
             }

--- a/Server/Forms/FrmRemoteShell.cs
+++ b/Server/Forms/FrmRemoteShell.cs
@@ -3,7 +3,6 @@ using System.Windows.Forms;
 using System.Drawing;
 using xServer.Core.Helper;
 using xServer.Core.Networking;
-using xServer.Core.Utilities;
 
 namespace xServer.Forms
 {
@@ -44,7 +43,7 @@ namespace xServer.Forms
 
         private void txtConsoleOutput_TextChanged(object sender, EventArgs e)
         {
-            NativeMethods.SendMessage(txtConsoleOutput.Handle, 277, 7, 0);
+            NativeMethodsHelper.ScrollToBottom(txtConsoleOutput.Handle);
         }
 
         private void txtConsoleInput_KeyDown(object sender, KeyEventArgs e)

--- a/Server/Forms/FrmRemoteShell.cs
+++ b/Server/Forms/FrmRemoteShell.cs
@@ -100,7 +100,7 @@ namespace xServer.Forms
             {
                 txtConsoleOutput.Invoke((MethodInvoker)delegate
                 {
-                    txtConsoleOutput.SelectionColor = Color.White;
+                    txtConsoleOutput.SelectionColor = Color.WhiteSmoke;
                     txtConsoleOutput.AppendText(message);
                 });
             }

--- a/Server/Forms/FrmRemoteShell.cs
+++ b/Server/Forms/FrmRemoteShell.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.Drawing;
 using xServer.Core.Helper;
 using xServer.Core.Networking;
+using xServer.Core.Utilities;
 
 namespace xServer.Forms
 {
@@ -43,8 +44,7 @@ namespace xServer.Forms
 
         private void txtConsoleOutput_TextChanged(object sender, EventArgs e)
         {
-            txtConsoleOutput.SelectionStart = txtConsoleOutput.TextLength;
-            txtConsoleOutput.ScrollToCaret();
+            NativeMethods.SendMessage(txtConsoleOutput.Handle, 277, 7, 0);
         }
 
         private void txtConsoleInput_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
-Will always scroll to the very bottom of the rtb when text is changed