### PR TITLE
fix client install directory bug in particular case

### DIFF
--- a/Quasar.Server/Build/ClientBuilder.cs
+++ b/Quasar.Server/Build/ClientBuilder.cs
@@ -209,7 +209,7 @@ namespace Quasar.Server.Build
             switch (installpath)
             {
                 case 1:
-                    return (sbyte)Environment.SpecialFolder.ApplicationData;
+                    return (sbyte)Environment.SpecialFolder.CommonApplicationData;
                 case 2:
                     return (sbyte)Environment.SpecialFolder.ProgramFilesX86;
                 case 3:

--- a/Quasar.Server/Forms/FrmBuilder.Designer.cs
+++ b/Quasar.Server/Forms/FrmBuilder.Designer.cs
@@ -672,7 +672,7 @@ namespace Quasar.Server.Forms
             this.rbAppdata.Size = new System.Drawing.Size(137, 17);
             this.rbAppdata.TabIndex = 3;
             this.rbAppdata.TabStop = true;
-            this.rbAppdata.Text = "User Application Data";
+            this.rbAppdata.Text = "Common Application Data";
             this.rbAppdata.UseVisualStyleBackColor = true;
             this.rbAppdata.CheckedChanged += new System.EventHandler(this.HasChangedSettingAndFilePath);
             // 

--- a/Quasar.Server/Forms/FrmBuilder.cs
+++ b/Quasar.Server/Forms/FrmBuilder.cs
@@ -415,7 +415,7 @@ namespace Quasar.Server.Forms
             if (rbAppdata.Checked)
                 path =
                     Path.Combine(
-                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                             txtInstallSubDirectory.Text), txtInstallName.Text);
             else if (rbProgramFiles.Checked)
                 path =


### PR DESCRIPTION
**use 'Common Application Data' replace 'User Application Data' as Client install directory to fix bug in particular case**

[https://github.com/quasar/QuasarRAT/issues/741#issue-395170419](https://github.com/quasar/QuasarRAT/issues/741#issue-395170419)

**Describe the bug**
in Client Builder,select "User Application Data" as client install directory,when the server's system login account not exist in client,it does not work.

**System**
 - Server OS: Windows 10,system account:work
 - Client OS: Windows 7,system account:Administrator
 - Quasar Version: 1.3.0

**To Reproduce**
Steps to reproduce the behavior:
1. quasar.exe->builder->Installation  Settings
2. install directory select 'User Application Data'
3. when the Server's login account is 'work',the client install directory become 'C:\Users\work\AppData\Roaming\SubDir\driver.exe'
4. then run client.exe in Client which not has work account ,the client.exe not install

**bug code**

- Quasar.Server\Forms\FrmBuilder.cs

```
        private void RefreshPreviewPath()
        {
            string path = string.Empty;
            if (rbAppdata.Checked)
                path =
                    Path.Combine(
                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                            txtInstallSubDirectory.Text), txtInstallName.Text);
            else if (rbProgramFiles.Checked)
                path =
                    Path.Combine(
                        Path.Combine(
                            Environment.GetFolderPath(PlatformHelper.Is64Bit
                                ? Environment.SpecialFolder.ProgramFilesX86
                                : Environment.SpecialFolder.ProgramFiles), txtInstallSubDirectory.Text), txtInstallName.Text);
            else if (rbSystem.Checked)
                path =
                    Path.Combine(
                        Path.Combine(
                            Environment.GetFolderPath(PlatformHelper.Is64Bit
                                ? Environment.SpecialFolder.SystemX86
                                : Environment.SpecialFolder.System), txtInstallSubDirectory.Text), txtInstallName.Text);

            this.Invoke((MethodInvoker)delegate { txtPreviewPath.Text = path + ".exe"; });
        }

        private short GetInstallPath()
        {
            if (rbAppdata.Checked) return 1;
            if (rbProgramFiles.Checked) return 2;
            if (rbSystem.Checked) return 3;
            throw new ArgumentException("InstallPath");
        }
```

- Quasar.Server\Build\ClientBuilder.cs

```
        private sbyte GetSpecialFolder(int installpath)
        {
            switch (installpath)
            {
                case 1:
                    return (sbyte)Environment.SpecialFolder.ApplicationData;
                case 2:
                    return (sbyte)Environment.SpecialFolder.ProgramFilesX86;
                case 3:
                    return (sbyte)Environment.SpecialFolder.SystemX86;
                default:
                    throw new ArgumentException("InstallPath");
            }
        }
```

**fix suggestion**    
use CommonApplicationData replace ApplicationData

- Quasar.Server\Forms\FrmBuilder.cs

```
        private void RefreshPreviewPath()
        {
            string path = string.Empty;
            if (rbAppdata.Checked)
                path =
                    Path.Combine(
                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                            txtInstallSubDirectory.Text), txtInstallName.Text);
            else if (rbProgramFiles.Checked)
                path =
                    Path.Combine(
                        Path.Combine(
                            Environment.GetFolderPath(PlatformHelper.Is64Bit
                                ? Environment.SpecialFolder.ProgramFilesX86
                                : Environment.SpecialFolder.ProgramFiles), txtInstallSubDirectory.Text), txtInstallName.Text);
            else if (rbSystem.Checked)
                path =
                    Path.Combine(
                        Path.Combine(
                            Environment.GetFolderPath(PlatformHelper.Is64Bit
                                ? Environment.SpecialFolder.SystemX86
                                : Environment.SpecialFolder.System), txtInstallSubDirectory.Text), txtInstallName.Text);

            this.Invoke((MethodInvoker)delegate { txtPreviewPath.Text = path + ".exe"; });
        }

        private short GetInstallPath()
        {
            if (rbAppdata.Checked) return 1;
            if (rbProgramFiles.Checked) return 2;
            if (rbSystem.Checked) return 3;
            throw new ArgumentException("InstallPath");
        }
```

- Quasar.Server\Build\ClientBuilder.cs

```
        private sbyte GetSpecialFolder(int installpath)
        {
            switch (installpath)
            {
                case 1:
                    return (sbyte)Environment.SpecialFolder.CommonApplicationData;
                case 2:
                    return (sbyte)Environment.SpecialFolder.ProgramFilesX86;
                case 3:
                    return (sbyte)Environment.SpecialFolder.SystemX86;
                default:
                    throw new ArgumentException("InstallPath");
            }
        }
```