### PR TITLE
Update protobuf-net from 2.4.0 to 2.4.4.

### DIFF
--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -48,7 +48,7 @@
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.4.4\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Quasar.Client/packages.config
+++ b/Quasar.Client/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MouseKeyHook" version="5.6.0" targetFramework="net40-client" />
-  <package id="protobuf-net" version="2.4.0" targetFramework="net40-client" />
+  <package id="protobuf-net" version="2.4.4" targetFramework="net40-client" />
 </packages>

--- a/Quasar.Common/Quasar.Common.csproj
+++ b/Quasar.Common/Quasar.Common.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.4.4\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -166,6 +166,5 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Quasar.Common/packages.config
+++ b/Quasar.Common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.4.0" targetFramework="net40-client" />
+  <package id="protobuf-net" version="2.4.4" targetFramework="net40-client" />
 </packages>

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -70,7 +70,7 @@
       <HintPath>..\packages\Mono.Nat.1.2.24.0\lib\net40\Mono.Nat.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.2.4.4\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="Vestris.ResourceLib, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Vestris.ResourceLib.2.1.0\lib\net40\Vestris.ResourceLib.dll</HintPath>

--- a/Quasar.Server/packages.config
+++ b/Quasar.Server/packages.config
@@ -5,6 +5,6 @@
   <package id="Mono.Cecil" version="0.10.3" targetFramework="net40-client" />
   <package id="Mono.Nat" version="1.2.24.0" targetFramework="net40-client" />
   <package id="MouseKeyHook" version="5.6.0" targetFramework="net40-client" />
-  <package id="protobuf-net" version="2.4.0" targetFramework="net40-client" />
+  <package id="protobuf-net" version="2.4.4" targetFramework="net40-client" />
   <package id="Vestris.ResourceLib" version="2.1.0" targetFramework="net40-client" />
 </packages>


### PR DESCRIPTION
- Note that the reference element "Version" attribute of the project files does change.